### PR TITLE
Expose stream and config

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
     "mkdirp": "^0.5.0",
     "node-rest-client": "^1.4.4",
     "unzip": "^0.1.11"
+  },
+  "devDependencies": {
+    "through2": "^0.6.3",
+    "vinyl": "^0.4.6"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 /*jslint node:true*/
-require('./index.js')({
+var fav = require('./index.js'),
+  config = {
     files: {
         //src: 'test/logo.png',
         src: {
@@ -27,7 +28,9 @@ require('./index.js')({
         url: 'http://haydenbleasel.com',
         logging: true
     }
-}, function (error, metadata) {
+  };
+
+fav(config, function (error, metadata) {
     'use strict';
     console.log(error, metadata);
 });


### PR DESCRIPTION
The exported object is still the familiar `favicons()` function. However, this function now has some properties: `setConfig()`, `generateFavicons()`, and `generateFaviconStream()`. The first two were basically present inside `index.js` before, but now we can `require()` them from elsewhere. `generateFaviconStream()` is the streaming interface that was previously hidden inside `generateFavicons()`, split out so stream-aware tools like [gulp](http://gulpjs.com/) can use it. The original test still works, now there's another test for `setConfig()` and `generateFaviconStream()`.

The code for `setConfig()` is kind of a mess, since I had to pull in other stuff that was scattered all over the place. Someone with a firmer vision for `favicons` options could improve this.

:smile: This is yet another "first step" in fixing haydenbleasel/gulp-favicons#2.