### PR TITLE
Minor fixes in icon resolution

### DIFF
--- a/data/icons.json
+++ b/data/icons.json
@@ -227,23 +227,23 @@
     },
     "mstile-150x150.png": {
       "type": "image",
-      "width": 150,
-      "height": 150
+      "width": 270,
+      "height": 270
     },
     "mstile-310x150.png": {
       "type": "image",
-      "width": 310,
-      "height": 150
+      "width": 558,
+      "height": 270
     },
     "mstile-310x310.png": {
       "type": "image",
-      "width": 310,
-      "height": 310
+      "width": 558,
+      "height": 558
     },
     "mstile-70x70.png": {
       "type": "image",
-      "width": 70,
-      "height": 70
+      "width": 128,
+      "height": 128
     }
   },
   "yandex": {

--- a/data/icons.json
+++ b/data/icons.json
@@ -93,8 +93,8 @@
     },
     "apple-touch-icon.png": {
       "type": "image",
-      "width": 60,
-      "height": 60,
+      "width": 180,
+      "height": 180,
       "html": "<meta name='apple-mobile-web-app-capable' content='yes'>"
     }
   },


### PR DESCRIPTION
The size of the `apple-touch-icon.png` is a classic.

The resolution of the Windows tiles is trickier, see https://realfavicongenerator.net/faq#windows_8_tile_dimensions