### PR TITLE
Fixed url in html

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 
 const path = require('path'),
+    url = require('url'),
     fs = require('fs'),
     _ = require('underscore'),
     color = require('tinycolor2'),
@@ -32,11 +33,11 @@ const path = require('path'),
         }
 
         function relative (directory) {
-            return path.join(options.path, directory);
+            return url.resolve(options.path, directory);
         }
 
         function absolute (directory) {
-            return path.join(options.url, directory);
+            return url.resolve(options.path, directory);
         }
 
         function print (context, message) {


### PR DESCRIPTION
When using on windows, the generated url contains a backslash.