### PR TITLE
Resolving error on .includes function

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -110,7 +110,7 @@ var path = require('path'),
                         value = $('*').first().attr(attribute);
 
                     if (path.extname(value)) {
-                        if (html.includes('og:image') || html.includes('twitter:image')) {
+                        if (html.indexOf('og:image') !== -1 || html.indexOf('twitter:image') !== -1) {
                             $('*').first().attr(attribute, absolute(value));
                         } else {
                             $('*').first().attr(attribute, relative(value));


### PR DESCRIPTION
I'm sure there's a better way to write this. Updating .includes to indexOf gives a correct match or not for the twitter / og values.

Also, it looks like the `absolute(value)` and `relative(value)` are the same anyway as noted [here](https://github.com/haydenbleasel/favicons/blob/master/helpers.js#L38-L44), so is [this condition](https://github.com/haydenbleasel/favicons/blob/master/helpers.js#L113) even necessary?

```javascript
function relative(directory) {
    return url.resolve(options.path, directory);
}

function absolute(directory) {
    return url.resolve(options.path, directory);
}
```