### PR TITLE
Allow the stream API to accept a callback for html

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,10 +156,6 @@ const _ = require('underscore'),
         });
     }
 
-  /**
-   * @param {Object} params
-   * @param {function(string)=} htmlCallback an optional function to be called with the generated HTML
-   */
     function stream (params, htmlCallback) {
 
         const µ = helpers(params);

--- a/index.js
+++ b/index.js
@@ -156,7 +156,11 @@ const _ = require('underscore'),
         });
     }
 
-    function stream (params) {
+  /**
+   * @param {Object} params
+   * @param {function(string)=} htmlCallback an optional function to be called with the generated HTML
+   */
+    function stream (params, htmlCallback) {
 
         const µ = helpers(params);
 
@@ -197,6 +201,10 @@ const _ = require('underscore'),
                     }, (error) =>
                         cb(error, response)),
                 (response, cb) => {
+                    if (htmlCallback) {
+                        htmlCallback(response.html);
+                    }
+
                     let documents = null;
 
                     if (params.html) {


### PR DESCRIPTION
#### What does this PR do?
Adds a way to get the generated HTML code (meta tags). The stream function is now taking an optional callback as a second argument. It is NOT mutually exclusive with the `html` option: if the `html` option is given it will still write the tags in the given file path. (BTW @haydenbleasel are you happy with this last bit?)

#### What are the relevant tickets
https://github.com/haydenbleasel/favicons/issues/83