### PR TITLE
Expose config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,7 @@ const _ = require('underscore'),
     }
 
     module.exports = favicons;
+    module.exports.config = config;
     module.exports.stream = stream;
 
 })();

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,13 @@ If you need an ES5 build for legacy purposes, just require the ES5 file:
 var favicons = require('favicons/es5');
 ```
 
+To programmatically access Favicons configuration, e.g. to work with
+its list of icon file names, HTML, or manifest files:
+
+```js
+var faviconsConfig = require('favicons').config;
+```
+
 You can also configure and use Favicons from the terminal with dot syntax:
 
 ```sh


### PR DESCRIPTION
Expose config so consumers of the module can programmatically get a list of files generated without having to read the `config/icons.json` file themselves.
Wanted for https://github.com/davewasmer/ember-cli-favicon/issues/5.

If you prefer, we can expose a deep clone of the config, so that modification isn't possible - though for that, we might want to upgrade from `underscore` to `lodash`.

If you're open to it, I want to go even further and expose a flattened list of files, e.g.:
```js
modules.exports.files = ['favicon.png'].concat(_(config.icons).map(function (icon) {
  return Object.keys(icon);
}).flatten().value());
```
Let me know and I can add that to this PR before you merge.