### PR TITLE
Fixed issue with multiple calls to favicons()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 const _ = require('underscore'),
     async = require('async'),
     through2 = require('through2'),
+    clone = require('clone'),
     mergeDefaults = require('merge-defaults'),
-    config = require('require-directory')(module, 'config'),
+    configDefaults = require('require-directory')(module, 'config'),
     helpers = require('./helpers.js');
 
 (() => {
@@ -13,7 +14,8 @@ const _ = require('underscore'),
 
     function favicons (source, parameters, next) {
 
-        const options = _.mergeDefaults(parameters || {}, config.defaults),
+        const config = clone(configDefaults),
+            options = _.mergeDefaults(parameters || {}, config.defaults),
             µ = helpers(options),
             background = µ.General.background(options.background);
 
@@ -158,7 +160,8 @@ const _ = require('underscore'),
 
     function stream (params) {
 
-        const µ = helpers(params);
+        const config = clone(configDefaults),
+            µ = helpers(params);
 
         function processDocuments (documents, html, callback) {
             async.each(documents, (document) =>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.1.18",
+    "clone": "^1.0.2",
     "eslint": "^1.9.0",
     "gulp": "^3.9.0",
     "mocha": "^2.3.4",


### PR DESCRIPTION
Unexpected results are occurring when `favicons()` is called multiple times with certain configurations. In my case, when `path` is different.

The unexpected result is that when "files" (manifest.json, browserconfig.xml, etc.) are being created the paths (i.e. `"path/android-chrome-36x36.png"`) are incorrect for any `favicons()` call that's made after already calling `favicons()`.

```js
// Forget the fact that favicons() is asynchronous in this example.

favicons('./favicon.png', {
  path: '/one'
});
// File path inside the created manifest.json:
// "\\one\\android-chrome-36x36.png"
// CORRECT

favicons('./favicon.png', {
  path: '/two'
});
// File path inside the created manifest.json:
// "\\two\\one\\android-chrome-36x36.png"
// INCORRECT - "\\one" was included in the path
```

This is happening because [`config`](https://github.com/haydenbleasel/favicons/blob/d3d200230eb8dad31c3038c6131a8c6272979d9f/index.js#L5) is the same object every time `favicons()` is called, which normally isn't an issue if it weren't for the fact that properties of `config` are [being overridden](https://github.com/haydenbleasel/favicons/blob/d3d200230eb8dad31c3038c6131a8c6272979d9f/helpers.js#L185) with each call.

The fix in this PR makes a deep copy of `config` so that each time `favicons` is called `config` is an accurate representation of what it's intended to be; the content of the files in /config.