### PR TITLE
Support web app install banner

### DIFF
--- a/config/files.json
+++ b/config/files.json
@@ -2,6 +2,7 @@
   "android": {
     "manifest.json": {
     	"name": "Favicons",
+    	"short_name": "Favicons",
       "display": "standalone",
     	"orientation": "portrait",
     	"icons": [

--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -187,6 +187,7 @@ var path = require('path'),
                     print('Files:create', 'Creating file: ' + name);
                     if (name === 'manifest.json') {
                         properties.name = options.appName;
+                        properties.short_name = options.appName;
                         properties.display = options.display;
                         properties.orientation = options.orientation;
                         _.map(properties.icons, function (icon) {


### PR DESCRIPTION
Add short_name in the manifest.json, required to display a web app install banner.
https://developers.google.com/web/fundamentals/engage-and-retain/simplified-app-installs/web-app-install-banners