### PR TITLE
Add gulp script and pipeHTML options

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -11,6 +11,7 @@
   "version": "1.0",
   "logging": false,
   "online": false,
+  "pipeHTML": false,
   "icons": {
     "android": true,
     "appleIcon": true,

--- a/es5.js
+++ b/es5.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj; }
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
 var _ = require('underscore'),
     async = require('async'),
@@ -11,6 +11,7 @@ var _ = require('underscore'),
     helpers = require('./helpers-es5.js');
 
 (function () {
+
     'use strict';
 
     _.mergeDefaults = mergeDefaults;
@@ -172,6 +173,11 @@ var _ = require('underscore'),
             return create(sourceset, function (error, response) {
                 return callback(error, response);
             });
+        }, function (response, callback) {
+            if (options.pipeHTML) µ.Files.create(response.html, options.html, function (error, file) {
+                response.files = response.files.concat([file]);
+                return callback(error, response);
+            });else return callback(null, response);
         }], function (error, response) {
             if (error && typeof error === 'string') {
                 error = { status: null, error: error, message: null };
@@ -240,7 +246,7 @@ var _ = require('underscore'),
 
                 var documents = null;
 
-                if (params.html) {
+                if (params.html && !params.pipeHTML) {
                     documents = _typeof(params.html) === 'object' ? params.html : [params.html];
                     processDocuments(documents, response.html, function (error) {
                         return cb(error);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,16 @@
+var gulp   = require('gulp'),
+	gulpif = require('gulp-if'),
+    babel  = require('gulp-babel'),
+    rename = require("gulp-rename");
+
+gulp.task('build', () => {
+    return gulp.src(['index.js', 'helpers.js'])
+    .pipe(babel({
+        presets: ['es2015']
+    }))
+    .pipe(gulpif(/^index\.js$/, rename('es5.js')))
+    .pipe(gulpif(/^helpers\.js$/, rename('helpers-es5.js')))
+    .pipe(gulp.dest('.'));
+});
+
+gulp.task('default', ['build']);

--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj; }
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
 /* eslint camelcase: 0, no-shadow: 0 */
 
@@ -21,6 +21,7 @@ var path = require('path'),
     NRC = require('node-rest-client').Client;
 
 (function () {
+
     'use strict';
 
     var xmlconfig = { prettyPrint: true, xmlHeader: true, indent: '  ' },
@@ -43,9 +44,7 @@ var path = require('path'),
         }
 
         function absolute(directory) {
-            var filepath = path.join(options.path, directory);
-
-            return url.resolve(options.url, filepath);
+            return url.resolve(options.url, relative(directory));
         }
 
         function print(context, message) {
@@ -222,6 +221,8 @@ var path = require('path'),
                         properties.layout.logo = relative(properties.layout.logo);
                         properties.layout.color = options.background;
                         properties = JSON.stringify(properties, null, 2);
+                    } else if (/\.html$/.test(name)) {
+                        properties = properties.join('\n');
                     }
                     return callback(null, { name: name, contents: properties });
                 }

--- a/helpers.js
+++ b/helpers.js
@@ -206,6 +206,8 @@ const path = require('path'),
                         properties.layout.logo = relative(properties.layout.logo);
                         properties.layout.color = options.background;
                         properties = JSON.stringify(properties, null, 2);
+                    } else if (/\.html$/.test(name)) {
+                        properties = properties.join('\n');
                     }
                     return callback(null, { name, contents: properties });
                 }

--- a/index.js
+++ b/index.js
@@ -141,7 +141,16 @@ const _ = require('underscore'),
                     callback(error, sourceset)),
             (sourceset, callback) =>
                 create(sourceset, (error, response) =>
-                    callback(error, response))
+                    callback(error, response)),
+            (response, callback) => {
+                if(options.pipeHTML)
+                    µ.Files.create(response.html, options.html, (error, file) => {
+                        response.files = response.files.concat([file]);
+                        return callback(error, response);
+                    });
+                else
+                    return callback(null, response);
+            }
         ], (error, response) => {
             if (error && typeof error === 'string') {
                 error = { status: null, error, message: null };
@@ -206,7 +215,7 @@ const _ = require('underscore'),
 
                     let documents = null;
 
-                    if (params.html) {
+                    if (params.html && !params.pipeHTML) {
                         documents = typeof params.html === 'object' ? params.html : [params.html];
                         processDocuments(documents, response.html, (error) =>
                             cb(error));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   "devDependencies": {
     "babel-preset-es2015": "^6.1.18",
     "eslint": "^1.9.0",
-    "gulp": "^3.9.0"
+    "gulp": "^3.9.0",
+    "gulp-babel": "^6.1.1",
+    "gulp-if": "^2.0.0",
+    "gulp-rename": "^1.2.2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@ gulp.task("default", function () {
         logging: false,
         online: false,
         html: "index.html",
+        pipeHTML: true,
         replace: true
     })).pipe(gulp.dest("./"));
 });

--- a/readme.md
+++ b/readme.md
@@ -115,16 +115,7 @@ For the full list of files, check `config/files.json`. For the full HTML code, c
 To build the ES5 version for Node.js:
 
 ```sh
-npm install -g babel-cli
-babel --presets es2015 index.js --out-file es5.js
-babel --presets es2015 helpers.js --out-file helpers-es5.js
-```
-
-To build the ES5 version for Gulp, run the following and remember to require the ES5 version.
-
-```sh
-npm install -g babel-cli
-babel --presets es2015 index.js --out-file es5.js
+gulp build
 ```
 
 ## Questions


### PR DESCRIPTION
As already explained in my issue 2 days ago, I wanted an option to pipe HTML in `gulp-favicons` for further transformations (in my case, to `jade`). A sample of what I accomplished is: 

```javascript
return gulp.src(['client/img/icon.svg'])
        .pipe(svg2png())
        .pipe(favicons({
                ...
                html: '../views/favicon.html',
                pipeHTML: true,
                ...
        }))
        .pipe(gulpif(/views\/favicon.html$/, html2jade()))
        .pipe(gulp.dest("public"));
```

This way, you can choose to pipe the generated html file through `html2jade` and save in it `public/../views/favicon.jade`.

As a bonus, I introduced a gulp file to automate es5 scripts generation :D

Highly appreciate it if you publish these updates to the `gulp-favicons` repository too.
Thanks!