### PR TITLE
Fix README example for Gulp.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ To use Favicons with Gulp, require the `gulp-favicons` wrapper and use it as fol
 var favicons = require("gulp-favicons");
 
 gulp.task("default", function () {
-    gulp.src("logo.png").pipe(favicons({
+    return gulp.src("logo.png").pipe(favicons({
         appName: "My App",
         appDescription: "This is my application",
         developerName: "Hayden Bleasel",


### PR DESCRIPTION
 We should return any pipelines we construct, so that the task doesn't finish until the pipeline finishes.

See https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulptaskname--deps-fn for more info:
"Note: Are your tasks running before the dependencies are complete? Make sure your dependency tasks are correctly using the async run hints: take in a callback or return a promise or event stream."