### PR TITLE
Fix (and simplify) error handling/callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "babel-preset-es2015": "^6.1.18",
     "eslint": "^1.9.0",
-    "gulp": "^3.9.0"
+    "gulp": "^3.9.0",
+    "gutil": "^1.6.4"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,8 @@ var config = require('favicons').config;
 To use Favicons with Gulp, require the `gulp-favicons` wrapper and use it as follows:
 
 ```js
-var favicons = require("gulp-favicons");
+var favicons = require("gulp-favicons"),
+    gutil = require("gutil");
 
 gulp.task("default", function () {
     gulp.src("logo.png").pipe(favicons({
@@ -96,7 +97,9 @@ gulp.task("default", function () {
         online: false,
         html: "index.html",
         replace: true
-    })).pipe(gulp.dest("./"));
+    }))
+    .on("error", gutil.log)
+    .pipe(gulp.dest("./"));
 });
 ```
 

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -1,4 +1,5 @@
 const gulp = require('gulp'),
+    gutil = require('gutil'),
     favicons = require('../').stream;
 
 (() => {
@@ -26,6 +27,7 @@ const gulp = require('gulp'),
                 html: 'stream.html',
                 replace: false
             }))
+            .on('error', gutil.log)
             .pipe(gulp.dest('stream/')));
 
 })();

--- a/test/stream.html
+++ b/test/stream.html
@@ -1,3 +1,38 @@
 <link rel="icon" type="image/png" sizes="192x192" href="custom/dir/android-chrome-192x192.png">
 <link rel="manifest" href="custom/dir/manifest.json">
 <meta name="mobile-web-app-capable" content="no">
+<meta name="theme-color" content="#26353F">
+<meta name="application-name" content="Favicons 4.0">
+<link rel="apple-touch-icon" sizes="57x57" href="stream/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="stream/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="stream/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="stream/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="stream/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="stream/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="stream/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="stream/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="stream/apple-touch-icon-180x180.png">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="Favicons 4.0">
+<link rel="icon" type="image/png" sizes="16x16" href="stream/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="stream/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="96x96" href="stream/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="230x230" href="stream/favicon-230x230.png">
+<link rel="shortcut icon" href="stream/favicon.ico">
+<meta property="twitter:image" content="http://haydenbleasel.com/stream/twitter.png">
+<link rel="yandex-tableau-widget" href="stream/yandex-browser-manifest.json">
+<meta name="msapplication-TileColor" content="#26353F">
+<meta name="msapplication-TileImage" content="stream/mstile-144x144.png">
+<meta name="msapplication-config" content="stream/browserconfig.xml">
+<meta property="og:image" content="http://haydenbleasel.com/stream/open-graph.png">
+<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 1)" href="stream/apple-touch-startup-image-320x460.png">
+<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)" href="stream/apple-touch-startup-image-640x920.png">
+<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" href="stream/apple-touch-startup-image-640x1096.png">
+<link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" href="stream/apple-touch-startup-image-750x1294.png">
+<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 3)" href="stream/apple-touch-startup-image-1182x2208.png">
+<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 3)" href="stream/apple-touch-startup-image-1242x2148.png">
+<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 1)" href="stream/apple-touch-startup-image-748x1024.png">
+<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 1)" href="stream/apple-touch-startup-image-768x1004.png">
+<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 2)" href="stream/apple-touch-startup-image-1496x2048.png">
+<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 2)" href="stream/apple-touch-startup-image-1536x2008.png">


### PR DESCRIPTION
- Simplify all our no-op callbacks.
- Favicon streams' processDocuments was calling the outer callback per-html-file, when that should wait until after all html files are processed.
- If someone passes a second function arg to stream(), we should still call the inner waterfall callback to ensure flow finishes and the stream can complete.
- The main favicons' error handling tried to construct a dict to represent the error, but constructed it in a way that actua
lly dropped the error message itself. We just return the raw error string now, as there's no real point to the dict AFAICT.
- The main favicons' code was attempting to access response.images (and other props), even when there was an error and response was empty, resulting in an inability to propagate the error up due to a new error occuring.
- The documentation now suggests using an .on('error', gutil.log) handler to display errors encountered in favicons (such as from the RFG server).