### PR TITLE
Require favicons/es5 in gulp branch es5.js

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var favicons = require('favicons');
+var favicons = require('favicons/es5');
 
 (function () {
     'use strict';


### PR DESCRIPTION
Fixes an error when requiring `gulp-favicons/es5`, where the (es6) index of `favicons` is required instead, breaking es5 environments.