### PR TITLE
contain icon, offset feature

### DIFF
--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -216,14 +216,19 @@ var path = require('path'),
                     print('Image:read', 'Reading file: ' + file.buffer);
                     Jimp.read(file, callback);
                 },
-                resize: function resize(image, minimum, callback) {
-                    print('Images:resize', 'Resizing image to ' + minimum + 'x' + minimum);
-                    image.resize(minimum, Jimp.AUTO);
+                resize: function resize(image, properties, offset, callback) {
+                    print('Images:resize', 'Resizing image to contain in ' + properties.width + 'x' + properties.height + ' with offset ' + offset);
+                    image.contain(properties.width, properties.height, Jimp.HORIZONTAL_ALIGN_CENTER | Jimp.VERTICAL_ALIGN_MIDDLE);
+
+                    if (offset) {
+                        image.resize(properties.width - offset, properties.height - offset);
+                    }
+                    
                     return callback(null, image);
                 },
-                composite: function composite(canvas, image, properties, minimum, callback) {
-                    var offsetHeight = properties.height - minimum > 0 ? (properties.height - minimum) / 2 : 0,
-                        offsetWidth = properties.width - minimum > 0 ? (properties.width - minimum) / 2 : 0,
+                composite: function composite(canvas, image, properties, maximum, callback) {
+                    var offsetHeight = properties.height - maximum > 0 ? (properties.height - maximum) / 2 : 0,
+                        offsetWidth = properties.width - maximum > 0 ? (properties.width - maximum) / 2 : 0,
                         circle = path.join(__dirname, 'mask.png'),
                         overlay = path.join(__dirname, 'overlay.png');
 
@@ -232,7 +237,7 @@ var path = require('path'),
                         image.rotate(ROTATE_DEGREES);
                     }
 
-                    print('Images:composite', 'Compositing ' + minimum + 'x' + minimum + ' favicon on ' + properties.width + 'x' + properties.height + ' canvas');
+                    print('Images:composite', 'Compositing ' + maximum + 'x' + maximum + ' favicon on ' + properties.width + 'x' + properties.height + ' canvas');
                     canvas.composite(image, offsetWidth, offsetHeight);
 
                     if (properties.mask) {
@@ -242,8 +247,8 @@ var path = require('path'),
                         }, function (cb) {
                             return Jimp.read(overlay, cb);
                         }], function (error, images) {
-                            images[0].resize(minimum, Jimp.AUTO);
-                            images[1].resize(minimum, Jimp.AUTO);
+                            images[0].resize(maximum, Jimp.AUTO);
+                            images[1].resize(maximum, Jimp.AUTO);
                             canvas.mask(images[0], 0, 0);
                             canvas.composite(images[1], 0, 0);
                             return callback(error, canvas);

--- a/index.js
+++ b/index.js
@@ -118,9 +118,7 @@ const _ = require('underscore'),
             const response = { images: [], files: [], html: [] };
 
             async.forEachOf(options.icons, (enabled, platform, cb) => {
-                const platformOptions = typeof enabled == "object"
-                    ? enabled
-                    : {};
+                const platformOptions = typeof enabled == "object" ? enabled : {};
 
                 if (enabled) {
                     createPlatform(sourceset, platform, platformOptions, (error, images, files, html) => {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const _ = require('underscore'),
             µ = helpers(options),
             background = µ.General.background(options.background);
 
-        function createFavicon (sourceset, properties, name, callback) {
+        function createFavicon (sourceset, properties, name, platformOptions, callback) {
             if (path.extname(name) === '.ico') {
                 async.map(
                     properties.sizes,
@@ -33,7 +33,7 @@ const _ = require('underscore'),
 
                         const tempName = `favicon-temp-${newProperties.width}x${newProperties.height}.png`;
 
-                        createFavicon(sourceset, newProperties, tempName, cb);
+                        createFavicon(sourceset, newProperties, tempName, platformOptions, cb);
                     },
                     (error, results) => {
                         const files = [];
@@ -49,18 +49,20 @@ const _ = require('underscore'),
                 );
             } else {
                 const minimum = Math.min(properties.width, properties.height),
-                    icon = _.min(sourceset, (ico) => ico.size >= minimum);
+                    maximum = Math.max(properties.width, properties.height),
+                    icon = _.min(sourceset, (ico) => ico.size >= minimum),
+                    offset = Math.round(maximum / 100 * platformOptions.offset) || 0;
 
                 async.waterfall([
                     (cb) =>
                         µ.Images.read(icon.file, cb),
                     (buffer, cb) =>
-                        µ.Images.resize(buffer, minimum, cb),
+                        µ.Images.resize(buffer, properties, offset, cb),
                     (resizedBuffer, cb) =>
                         µ.Images.create(properties, background, (error, canvas) =>
                             cb(error, resizedBuffer, canvas)),
                     (resizedBuffer, canvas, cb) =>
-                        µ.Images.composite(canvas, resizedBuffer, properties, minimum, cb),
+                        µ.Images.composite(canvas, resizedBuffer, properties, maximum - offset, cb),
                     (composite, cb) => {
                         µ.Images.getBuffer(composite, cb);
                     }
@@ -90,20 +92,20 @@ const _ = require('underscore'),
                 callback(error, files));
         }
 
-        function createFavicons (sourceset, platform, callback) {
+        function createFavicons (sourceset, platform, platformOptions, callback) {
             const images = [];
 
             async.forEachOf(config.icons[platform], (properties, name, cb) =>
-                createFavicon(sourceset, properties, name, (error, image) =>
+                createFavicon(sourceset, properties, name, platformOptions, (error, image) =>
                     cb(images.push(image) && error)),
             (error) =>
                 callback(error, images));
         }
 
-        function createPlatform (sourceset, platform, callback) {
+        function createPlatform (sourceset, platform, platformOptions, callback) {
             async.parallel([
                 (cb) =>
-                    createFavicons(sourceset, platform, cb),
+                    createFavicons(sourceset, platform, platformOptions, cb),
                 (cb) =>
                     createFiles(platform, cb),
                 (cb) =>
@@ -116,8 +118,12 @@ const _ = require('underscore'),
             const response = { images: [], files: [], html: [] };
 
             async.forEachOf(options.icons, (enabled, platform, cb) => {
+                const platformOptions = typeof enabled == "object"
+                    ? enabled
+                    : {};
+
                 if (enabled) {
-                    createPlatform(sourceset, platform, (error, images, files, html) => {
+                    createPlatform(sourceset, platform, platformOptions, (error, images, files, html) => {
                         response.images = response.images.concat(images);
                         response.files = response.files.concat(files);
                         response.html = response.html.concat(html);

--- a/readme.md
+++ b/readme.md
@@ -35,14 +35,14 @@ var favicons = require('favicons'),
         logging: false,                 // Print logs to console? `boolean`
         online: false,                  // Use RealFaviconGenerator to create favicons? `boolean`
         icons: {
-            android: true,              // Create Android homescreen icon. `boolean`
-            appleIcon: true,            // Create Apple touch icons. `boolean`
-            appleStartup: true,         // Create Apple startup images. `boolean`
-            coast: true,                // Create Opera Coast icon. `boolean`
-            favicons: true,             // Create regular favicons. `boolean`
-            firefox: true,              // Create Firefox OS icons. `boolean`
-            windows: true,              // Create Windows 8 tile icons. `boolean`
-            yandex: true                // Create Yandex browser icon. `boolean`
+            android: true,              // Create Android homescreen icon. `boolean` or `{ offset: offsetInPercentage }`
+            appleIcon: true,            // Create Apple touch icons. `boolean` or `{ offset: offsetInPercentage }`
+            appleStartup: true,         // Create Apple startup images. `boolean` or `{ offset: offsetInPercentage }`
+            coast: { offset: 25 },      // Create Opera Coast icon with offset 25%. `boolean` or `{ offset: offsetInPercentage }`
+            favicons: true,             // Create regular favicons. `boolean` or `{ offset: offsetInPercentage }`
+            firefox: true,              // Create Firefox OS icons. `boolean` or `{ offset: offsetInPercentage }`
+            windows: true,              // Create Windows 8 tile icons. `boolean` or `{ offset: offsetInPercentage }`
+            yandex: true                // Create Yandex browser icon. `boolean` or `{ offset: offsetInPercentage }`
         }
     },
     callback = function (error, response) {


### PR DESCRIPTION
Source:
![source](https://puu.sh/qHcrC/f06f8018e9.png)
Before:
![before](https://puu.sh/qHcnl/18673e1307.png)
After:
![after](https://puu.sh/qHcpi/9c464a3def.png)
After with offset:
![after with offset](https://puu.sh/qHcpU/cba5b4a1ba.png)

Now you can set offset (in percents) in config, example:
```js
let config = {
    background: "#0030d9",
    logging: true, 
    online: false,
    icons: {
        android:      false, // Create Android homescreen icon. `boolean`
        appleIcon:    { offset: 30 }, // Create Apple touch icons. `boolean`
        appleStartup: false, // Create Apple startup images. `boolean`
        firefox:      false, // Create Firefox OS icons. `boolean`
        windows:      false, // Create Windows 8 tile icons. `boolean`
        coast:        { offset: 30 },  // Create Opera Coast icon. `boolean`
        favicons:     true,  // Create regular favicons. `boolean`
        yandex:       true   // Create Yandex browser icon. `boolean`
    }
};
```