### PR TITLE
Some fixes, some mods

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -12,6 +12,7 @@
   "version": "1.0",
   "logging": false,
   "online": false,
+  "preferOnline": false,
   "pipeHTML": false,
   "icons": {
     "android": true,

--- a/config/platform-options.json
+++ b/config/platform-options.json
@@ -1,0 +1,6 @@
+{
+	"offset": {
+		"platforms": ["appleIcon", "firefox", "coast"],
+		"defaultTo": 0
+	}
+}

--- a/config/rfg.json
+++ b/config/rfg.json
@@ -12,7 +12,7 @@
 		"desktop_browser": {},
 		"ios": {
 			"picture_aspect": "background_and_margin",
-			"margin": "4",
+			"margin": "0",
 			"background_color": "#FFFFFF",
 			"startup_image": {
 				"background_color": "#FFFFFF"
@@ -25,7 +25,8 @@
 		"firefox_app": {
 			"picture_aspect": "circle",
 			"keep_picture_in_circle": "true",
-			"circle_inner_margin": "5",
+			"circle_inner_margin": "0",
+			"margin": "0",
 			"background_color": "#FFFFFF",
 			"manifest": {
 				"app_name": "Favicons",
@@ -35,7 +36,7 @@
 			}
 		},
 		"android_chrome": {
-			"picture_aspect": "shadow",
+			"picture_aspect": "no_change",
 			"manifest": {
 				"name": "Favicons",
 				"display": "standalone",
@@ -46,7 +47,7 @@
 		"coast": {
 			"picture_aspect": "background_and_margin",
 			"background_color": "#FFFFFF",
-			"margin": "12%"
+			"margin": "0"
 		},
 		"yandex_browser": {
 			"background_color": "#FFFFFF",

--- a/es5.js
+++ b/es5.js
@@ -53,7 +53,7 @@ var _ = require('underscore'),
                         offset = Math.round(maximum / 100 * platformOptions.offset) || 0;
 
                     async.waterfall([function (cb) {
-                        return µ.Images.nearest(sourceset, properties);
+                        return µ.Images.nearest(sourceset, properties, offset, cb);
                     }, function (nearest, cb) {
                         return µ.Images.read(nearest.file, cb);
                     }, function (buffer, cb) {
@@ -63,7 +63,7 @@ var _ = require('underscore'),
                             return cb(error, resizedBuffer, canvas);
                         });
                     }, function (resizedBuffer, canvas, cb) {
-                        return µ.Images.composite(canvas, resizedBuffer, properties, maximum - offset, cb);
+                        return µ.Images.composite(canvas, resizedBuffer, properties, offset, maximum, cb);
                     }, function (composite, cb) {
                         µ.Images.getBuffer(composite, cb);
                     }], function (error, buffer) {
@@ -125,7 +125,7 @@ var _ = require('underscore'),
             var response = { images: [], files: [], html: [] };
 
             async.forEachOf(options.icons, function (enabled, platform, cb) {
-                var platformOptions = (typeof enabled === 'undefined' ? 'undefined' : _typeof(enabled)) == "object" ? enabled : {};
+                var platformOptions = µ.General.preparePlatformOptions(platform, enabled);
 
                 if (enabled) {
                     createPlatform(sourceset, platform, platformOptions, function (error, images, files, html) {

--- a/es5.js
+++ b/es5.js
@@ -37,15 +37,19 @@ var _ = require('underscore'),
 
                     createFavicon(sourceset, newProperties, tempName, platformOptions, cb);
                 }, function (error, results) {
+                    if (error) {
+                        return callback(error);
+                    }
+
                     var files = [];
 
                     results.forEach(function (icoImage) {
-                        files.push(icoImage.contents);
+                        return files.push(icoImage.contents);
                     });
 
                     toIco(files).then(function (buffer) {
-                        callback(error, { name: name, contents: buffer });
-                    });
+                        return callback(null, { name: name, contents: buffer });
+                    }).catch(callback);
                 });
             } else {
                 (function () {

--- a/es5.js
+++ b/es5.js
@@ -41,10 +41,8 @@ var _ = require('underscore'),
                         return callback(error);
                     }
 
-                    var files = [];
-
-                    results.forEach(function (icoImage) {
-                        return files.push(icoImage.contents);
+                    var files = results.map(function (icoImage) {
+                        return icoImage.contents;
                     });
 
                     toIco(files).then(function (buffer) {

--- a/es5.js
+++ b/es5.js
@@ -143,7 +143,7 @@ var _ = require('underscore'),
         }
 
         function unpack(pack, callback) {
-            var response = { images: [], files: [], html: pack.html.split(',') };
+            var response = { images: [], files: [], html: pack.html.split('\n') };
 
             async.each(pack.files, function (url, cb) {
                 return µ.RFG.fetch(url, function (error, box) {
@@ -162,12 +162,16 @@ var _ = require('underscore'),
             }, function (pack, cb) {
                 return unpack(pack, cb);
             }], function (error, results) {
-                return callback(error, results);
+                if (error && options.preferOnline) {
+                    createOffline(sourceset, callback);
+                } else {
+                    callback(error, results);
+                }
             });
         }
 
         function create(sourceset, callback) {
-            options.online ? createOnline(sourceset, callback) : createOffline(sourceset, callback);
+            options.online || options.preferOnline ? createOnline(sourceset, callback) : createOffline(sourceset, callback);
         }
 
         async.waterfall([function (callback) {

--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -253,7 +253,7 @@ var path = require('path'),
                     return Jimp.read(file, callback);
                 },
                 nearest: function nearest(sourceset, properties, offset, callback) {
-                    print('Image:nearest', 'Find nearest icon to ' + properties.width + 'x' + properties.height + ' with offset ' + offset + '%');
+                    print('Image:nearest', 'Find nearest icon to ' + properties.width + 'x' + properties.height + ' with offset ' + offset);
 
                     var offsetSize = offset * 2,
                         width = properties.width - offsetSize,
@@ -288,7 +288,7 @@ var path = require('path'),
                     }
                 },
                 resize: function resize(image, properties, offset, callback) {
-                    print('Images:resize', 'Resizing image to contain in ' + properties.width + 'x' + properties.height + ' with offset ' + offset + '%');
+                    print('Images:resize', 'Resizing image to contain in ' + properties.width + 'x' + properties.height + ' with offset ' + offset);
                     var offsetSize = offset * 2;
                     image.contain(properties.width - offsetSize, properties.height - offsetSize, Jimp.HORIZONTAL_ALIGN_CENTER | Jimp.VERTICAL_ALIGN_MIDDLE);
                     return callback(null, image);
@@ -307,7 +307,7 @@ var path = require('path'),
                     }
 
                     var compositeIcon = function compositeIcon() {
-                        print('Images:composite', 'Compositing ' + maximum + 'x' + maximum + ' favicon on ' + properties.width + 'x' + properties.height + ' canvas with offset ' + offset + '%');
+                        print('Images:composite', 'Compositing ' + maximum + 'x' + maximum + ' favicon on ' + properties.width + 'x' + properties.height + ' canvas with offset ' + offset);
                         canvas.composite(image, offsetWidth, offsetHeight);
                     };
 

--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -342,6 +342,7 @@ var path = require('path'),
                     var svgSource = _.find(sourceset, function (source) {
                         return source.size.type == 'svg';
                     });
+                    options.background = '#' + color(options.background).toHex();
                     request.master_picture.content = (svgSource || _.max(sourceset, function (_ref2) {
                         var _ref2$size = _ref2.size;
                         var width = _ref2$size.width;

--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -79,9 +79,35 @@ var path = require('path'),
             });
         }
 
+        function preparePlatformOptions(platform, options) {
+            if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) != 'object') {
+                options = {};
+            }
+
+            _.each(options, function (value, key) {
+                var platformOptionsRef = PLATFORM_OPTIONS[key];
+
+                if (typeof platformOptionsRef == 'undefined' || platformOptionsRef.platforms.indexOf(platform) == -1) {
+                    return Reflect.deleteProperty(options, key);
+                }
+            });
+
+            _.each(PLATFORM_OPTIONS, function (_ref, key) {
+                var platforms = _ref.platforms;
+                var defaultTo = _ref.defaultTo;
+
+                if (typeof options[key] == 'undefined' && platforms.indexOf(platform) != -1) {
+                    options[key] = defaultTo;
+                }
+            });
+
+            return options;
+        }
+
         return {
 
             General: {
+                preparePlatformOptions: preparePlatformOptions,
                 background: function background(hex) {
                     print('General:background', 'Parsing colour ' + hex);
                     var rgba = color(hex).toRgb();
@@ -125,30 +151,6 @@ var path = require('path'),
                     } else {
                         return callback('Invalid source type provided');
                     }
-                },
-                preparePlatformOptions: function preparePlatformOptions(platform, options) {
-                    if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) != 'object') {
-                        options = {};
-                    }
-
-                    _.each(options, function (value, key) {
-                        var platformOptionsRef = PLATFORM_OPTIONS[key];
-
-                        if (typeof platformOptionsRef == 'undefined' || platformOptionsRef.platforms.indexOf(platform) == -1) {
-                            return Reflect.deleteProperty(options, key);
-                        }
-                    });
-
-                    _.each(PLATFORM_OPTIONS, function (_ref, key) {
-                        var platforms = _ref.platforms;
-                        var defaultTo = _ref.defaultTo;
-
-                        if (typeof options[key] == 'undefined' && platforms.indexOf(platform) != -1) {
-                            options[key] = defaultTo;
-                        }
-                    });
-
-                    return options;
                 },
                 vinyl: function vinyl(object) {
                     return new File({
@@ -358,9 +360,9 @@ var path = require('path'),
                     }
 
                     if (options.icons.appleIcon) {
-                        var offset = _.property('offset')(options.icons.appleIcon) || 0;
+                        var appleIconOptions = preparePlatformOptions('appleIcon', options.icons.appleIcon);
                         request.favicon_design.ios.background_color = options.background;
-                        request.favicon_design.ios.margin = Math.round(57 / 100 * offset);
+                        request.favicon_design.ios.margin = Math.round(57 / 100 * appleIconOptions.offset);
                     } else {
                         Reflect.deleteProperty(request.favicon_design, 'ios');
                     }
@@ -372,9 +374,9 @@ var path = require('path'),
                     }
 
                     if (options.icons.coast) {
-                        var _offset = _.property('offset')(options.icons.coast) || 0;
+                        var coastOptions = preparePlatformOptions('coast', options.icons.coast);
                         request.favicon_design.coast.background_color = options.background;
-                        request.favicon_design.coast.margin = Math.round(228 / 100 * _offset);
+                        request.favicon_design.coast.margin = Math.round(228 / 100 * coastOptions.offset);
                     } else {
                         Reflect.deleteProperty(request.favicon_design, 'coast');
                     }
@@ -384,9 +386,9 @@ var path = require('path'),
                     }
 
                     if (options.icons.firefox) {
-                        var _offset2 = _.property('offset')(options.icons.firefox) || 0;
+                        var firefoxOptions = preparePlatformOptions('firefox', options.icons.firefox);
                         request.favicon_design.firefox_app.background_color = options.background;
-                        request.favicon_design.firefox_app.margin = Math.round(60 / 100 * _offset2);
+                        request.favicon_design.firefox_app.margin = Math.round(60 / 100 * firefoxOptions.offset);
                         request.favicon_design.firefox_app.manifest.app_name = options.appName;
                         request.favicon_design.firefox_app.manifest.app_description = options.appDescription;
                         request.favicon_design.firefox_app.manifest.developer_name = options.developerName;

--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -15,6 +15,7 @@ var path = require('path'),
     async = require('async'),
     mkdirp = require('mkdirp'),
     Jimp = require('jimp'),
+    svg2png = require('svg2png'),
     File = require('vinyl'),
     Reflect = require('harmony-reflect'),
     NRC = require('node-rest-client').Client;
@@ -212,9 +213,20 @@ var path = require('path'),
                         return callback(error, canvas, jimp);
                     });
                 },
-                read: function read(file, callback) {
-                    print('Image:read', 'Reading file: ' + file.buffer);
-                    Jimp.read(file, callback);
+                read: function read(file, type, callback) {
+                    print('Image:read', 'Reading file: ' + file.buffer + ' with type ' + type);
+
+                    function readFile(file) {
+                        Jimp.read(file, callback);
+                    }
+
+                    if (type == 'svg') {
+                        svg2png(file, { width: 512, height: 512 })
+                            .then(readFile)
+                            .catch(callback);
+                    } else {
+                        readFile(file);
+                    }
                 },
                 resize: function resize(image, properties, offset, callback) {
                     print('Images:resize', 'Resizing image to contain in ' + properties.width + 'x' + properties.height + ' with offset ' + offset);

--- a/helpers.js
+++ b/helpers.js
@@ -323,6 +323,7 @@ const path = require('path'),
                 configure: (sourceset, request, callback) => {
                     print('RFG:configure', 'Configuring RFG API request');
                     const svgSource = _.find(sourceset, (source) => source.size.type == 'svg');
+                    options.background = `#${ color(options.background).toHex() }`;
                     request.master_picture.content = (svgSource || _.max(sourceset, ({ size: { width, height }}) => Math.max(width, height))).file.toString('base64');
                     request.files_location.path = options.path;
 

--- a/helpers.js
+++ b/helpers.js
@@ -75,9 +75,32 @@ const path = require('path'),
             });
         }
 
+        function preparePlatformOptions(platform, options) {
+            if (typeof options != 'object') {
+                options = {};
+            }
+
+            _.each(options, (value, key) => {
+                let platformOptionsRef = PLATFORM_OPTIONS[key];
+
+                if (typeof platformOptionsRef == 'undefined' || platformOptionsRef.platforms.indexOf(platform) == -1) {
+                    return Reflect.deleteProperty(options, key);
+                }
+            });
+
+            _.each(PLATFORM_OPTIONS, ({ platforms, defaultTo }, key) => {
+                if (typeof options[key] == 'undefined' && platforms.indexOf(platform) != -1) {
+                    options[key] = defaultTo;
+                }
+            });
+
+            return options;
+        }
+
         return {
 
             General: {
+                preparePlatformOptions: preparePlatformOptions,
                 background: (hex) => {
                     print('General:background', `Parsing colour ${ hex }`);
                     const rgba = color(hex).toRgb();
@@ -121,27 +144,6 @@ const path = require('path'),
                     } else {
                         return callback('Invalid source type provided');
                     }
-                },
-                preparePlatformOptions: (platform, options) => {
-                    if (typeof options != 'object') {
-                        options = {};
-                    }
-
-                    _.each(options, (value, key) => {
-                        let platformOptionsRef = PLATFORM_OPTIONS[key];
-
-                        if (typeof platformOptionsRef == 'undefined' || platformOptionsRef.platforms.indexOf(platform) == -1) {
-                            return Reflect.deleteProperty(options, key);
-                        }
-                    });
-
-                    _.each(PLATFORM_OPTIONS, ({ platforms, defaultTo }, key) => {
-                        if (typeof options[key] == 'undefined' && platforms.indexOf(platform) != -1) {
-                            options[key] = defaultTo;
-                        }
-                    });
-
-                    return options;
                 },
                 vinyl: (object) =>
                     new File({
@@ -334,9 +336,9 @@ const path = require('path'),
                     }
 
                     if (options.icons.appleIcon) {
-                        let offset = _.property('offset')(options.icons.appleIcon) || 0;
+                        let appleIconOptions = preparePlatformOptions('appleIcon', options.icons.appleIcon);
                         request.favicon_design.ios.background_color = options.background;
-                        request.favicon_design.ios.margin = Math.round(57 / 100 * offset);
+                        request.favicon_design.ios.margin = Math.round(57 / 100 * appleIconOptions.offset);
                     } else {
                         Reflect.deleteProperty(request.favicon_design, 'ios');
                     }
@@ -348,9 +350,9 @@ const path = require('path'),
                     }
 
                     if (options.icons.coast) {
-                        let offset = _.property('offset')(options.icons.coast) || 0;
+                        let coastOptions = preparePlatformOptions('coast', options.icons.coast);
                         request.favicon_design.coast.background_color = options.background;
-                        request.favicon_design.coast.margin = Math.round(228 / 100 * offset);
+                        request.favicon_design.coast.margin = Math.round(228 / 100 * coastOptions.offset);
                     } else {
                         Reflect.deleteProperty(request.favicon_design, 'coast');
                     }
@@ -360,9 +362,9 @@ const path = require('path'),
                     }
 
                     if (options.icons.firefox) {
-                        let offset = _.property('offset')(options.icons.firefox) || 0;
+                        let firefoxOptions = preparePlatformOptions('firefox', options.icons.firefox);
                         request.favicon_design.firefox_app.background_color = options.background;
-                        request.favicon_design.firefox_app.margin = Math.round(60 / 100 * offset);
+                        request.favicon_design.firefox_app.margin = Math.round(60 / 100 * firefoxOptions.offset);
                         request.favicon_design.firefox_app.manifest.app_name = options.appName;
                         request.favicon_design.firefox_app.manifest.app_description = options.appDescription;
                         request.favicon_design.firefox_app.manifest.developer_name = options.developerName;

--- a/helpers.js
+++ b/helpers.js
@@ -239,7 +239,7 @@ const path = require('path'),
                     return Jimp.read(file, callback);
                 },
                 nearest: (sourceset, properties, offset, callback) => {
-                    print('Image:nearest', `Find nearest icon to ${ properties.width }x${ properties.height } with offset ${ offset }%`);
+                    print('Image:nearest', `Find nearest icon to ${ properties.width }x${ properties.height } with offset ${ offset }`);
                     
                     const offsetSize = offset * 2,
                         width = properties.width - offsetSize,
@@ -272,7 +272,7 @@ const path = require('path'),
                     }
                 },
                 resize: (image, properties, offset, callback) => {
-                    print('Images:resize', `Resizing image to contain in ${ properties.width }x${ properties.height } with offset ${ offset }%`);
+                    print('Images:resize', `Resizing image to contain in ${ properties.width }x${ properties.height } with offset ${ offset }`);
                     let offsetSize = offset * 2;
                     image.contain(properties.width - offsetSize, properties.height - offsetSize, Jimp.HORIZONTAL_ALIGN_CENTER | Jimp.VERTICAL_ALIGN_MIDDLE);                    
                     return callback(null, image);
@@ -291,7 +291,7 @@ const path = require('path'),
                     }
 
                     const compositeIcon = () => {
-                        print('Images:composite', `Compositing ${ maximum }x${ maximum } favicon on ${ properties.width }x${ properties.height } canvas with offset ${ offset }%`);
+                        print('Images:composite', `Compositing ${ maximum }x${ maximum } favicon on ${ properties.width }x${ properties.height } canvas with offset ${ offset }`);
                         canvas.composite(image, offsetWidth, offsetHeight);
                     };
 

--- a/index.js
+++ b/index.js
@@ -36,15 +36,17 @@ const _ = require('underscore'),
                         createFavicon(sourceset, newProperties, tempName, platformOptions, cb);
                     },
                     (error, results) => {
+                        if (error) {
+                            return callback(error);
+                        }
+
                         const files = [];
 
-                        results.forEach((icoImage) => {
-                            files.push(icoImage.contents);
-                        });
+                        results.forEach((icoImage) => files.push(icoImage.contents));
 
-                        toIco(files).then((buffer) => {
-                            callback(error, { name, contents: buffer });
-                        });
+                        toIco(files)
+                            .then((buffer) => callback(null, { name, contents: buffer }))
+                            .catch(callback);
                     }
                 );
             } else {

--- a/index.js
+++ b/index.js
@@ -40,9 +40,7 @@ const _ = require('underscore'),
                             return callback(error);
                         }
 
-                        const files = [];
-
-                        results.forEach((icoImage) => files.push(icoImage.contents));
+                        const files = results.map((icoImage) => icoImage.contents);
 
                         toIco(files)
                             .then((buffer) => callback(null, { name, contents: buffer }))

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ const _ = require('underscore'),
         }
 
         function unpack (pack, callback) {
-            const response = { images: [], files: [], html: pack.html.split(',') };
+            const response = { images: [], files: [], html: pack.html.split('\n') };
 
             async.each(pack.files, (url, cb) =>
                 µ.RFG.fetch(url, (error, box) =>
@@ -152,12 +152,17 @@ const _ = require('underscore'),
                     µ.RFG.request(request, cb),
                 (pack, cb) =>
                     unpack(pack, cb)
-            ], (error, results) =>
-                callback(error, results));
+            ], (error, results) => {
+                if (error && options.preferOnline) {
+                    createOffline(sourceset, callback)
+                } else {
+                    callback(error, results);
+                }
+            });
         }
 
         function create (sourceset, callback) {
-            options.online ? createOnline(sourceset, callback) : createOffline(sourceset, callback);
+            options.online || options.preferOnline ? createOnline(sourceset, callback) : createOffline(sourceset, callback);
         }
 
         async.waterfall([

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const _ = require('underscore'),
 
                 async.waterfall([
                     (cb) =>
-                        µ.Images.nearest(sourceset, properties, cb),
+                        µ.Images.nearest(sourceset, properties, offset, cb),
                     (nearest, cb) =>
                         µ.Images.read(nearest.file, cb),
                     (buffer, cb) =>
@@ -62,7 +62,7 @@ const _ = require('underscore'),
                         µ.Images.create(properties, background, (error, canvas) =>
                             cb(error, resizedBuffer, canvas)),
                     (resizedBuffer, canvas, cb) =>
-                        µ.Images.composite(canvas, resizedBuffer, properties, maximum - offset, cb),
+                        µ.Images.composite(canvas, resizedBuffer, properties, offset, maximum, cb),
                     (composite, cb) => {
                         µ.Images.getBuffer(composite, cb);
                     }
@@ -118,7 +118,7 @@ const _ = require('underscore'),
             const response = { images: [], files: [], html: [] };
 
             async.forEachOf(options.icons, (enabled, platform, cb) => {
-                const platformOptions = typeof enabled == "object" ? enabled : {};
+                const platformOptions = µ.General.preparePlatformOptions(platform, enabled);
 
                 if (enabled) {
                     createPlatform(sourceset, platform, platformOptions, (error, images, files, html) => {

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const _ = require('underscore'),
 
                 async.waterfall([
                     (cb) =>
-                        µ.Images.read(icon.file, cb),
+                        µ.Images.read(icon.file, icon.size.type, cb),
                     (buffer, cb) =>
                         µ.Images.resize(buffer, properties, offset, cb),
                     (resizedBuffer, cb) =>

--- a/index.js
+++ b/index.js
@@ -48,14 +48,14 @@ const _ = require('underscore'),
                     }
                 );
             } else {
-                const minimum = Math.min(properties.width, properties.height),
-                    maximum = Math.max(properties.width, properties.height),
-                    icon = _.min(sourceset, (ico) => ico.size >= minimum),
+                const maximum = Math.max(properties.width, properties.height),
                     offset = Math.round(maximum / 100 * platformOptions.offset) || 0;
 
                 async.waterfall([
                     (cb) =>
-                        µ.Images.read(icon.file, icon.size.type, cb),
+                        µ.Images.nearest(sourceset, properties, cb),
+                    (nearest, cb) =>
+                        µ.Images.read(nearest.file, cb),
                     (buffer, cb) =>
                         µ.Images.resize(buffer, properties, offset, cb),
                     (resizedBuffer, cb) =>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mkdirp": "^0.5.1",
     "node-rest-client": "^1.5.1",
     "require-directory": "^2.1.1",
+    "svg2png": "^3.0.1",
     "through2": "^2.0.0",
     "tinycolor2": "^1.1.2",
     "to-ico": "^1.0.1",

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ var favicons = require('favicons'),
         version: "1.0",                 // Your application's version number. `number`
         logging: false,                 // Print logs to console? `boolean`
         online: false,                  // Use RealFaviconGenerator to create favicons? `boolean`
+        preferOnline: false,            // Use offline generation, if online generation has failed. `boolean`
         icons: {
             android: true,              // Create Android homescreen icon. `boolean`
             appleIcon: true,            // Create Apple touch icons. `boolean` or `{ offset: offsetInPercentage }`

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Please note: Favicons is written in ES6, meaning you need Node 4.x or above.
 
 ```js
 var favicons = require('favicons'),
-    source = 'test/logo.png',           // Source image(s). `string`, `buffer` or array of `{ size: filepath }`
+    source = 'test/logo.png',           // Source image(s). `string`, `buffer` or array of `string`
     configuration = {
         appName: null,                  // Your application's name. `string`
         appDescription: null,           // Your application's description. `string`

--- a/readme.md
+++ b/readme.md
@@ -35,14 +35,14 @@ var favicons = require('favicons'),
         logging: false,                 // Print logs to console? `boolean`
         online: false,                  // Use RealFaviconGenerator to create favicons? `boolean`
         icons: {
-            android: true,              // Create Android homescreen icon. `boolean` or `{ offset: offsetInPercentage }`
+            android: true,              // Create Android homescreen icon. `boolean`
             appleIcon: true,            // Create Apple touch icons. `boolean` or `{ offset: offsetInPercentage }`
-            appleStartup: true,         // Create Apple startup images. `boolean` or `{ offset: offsetInPercentage }`
+            appleStartup: true,         // Create Apple startup images. `boolean`
             coast: { offset: 25 },      // Create Opera Coast icon with offset 25%. `boolean` or `{ offset: offsetInPercentage }`
-            favicons: true,             // Create regular favicons. `boolean` or `{ offset: offsetInPercentage }`
+            favicons: true,             // Create regular favicons. `boolean`
             firefox: true,              // Create Firefox OS icons. `boolean` or `{ offset: offsetInPercentage }`
-            windows: true,              // Create Windows 8 tile icons. `boolean` or `{ offset: offsetInPercentage }`
-            yandex: true                // Create Yandex browser icon. `boolean` or `{ offset: offsetInPercentage }`
+            windows: true,              // Create Windows 8 tile icons. `boolean`
+            yandex: true                // Create Yandex browser icon. `boolean`
         }
     },
     callback = function (error, response) {


### PR DESCRIPTION
# Fixes
### 1. `source` parameter as argument
In documentation we can see: 
> or array of `{ size: filepath }`

but according to the code it should be map, not array:
```js
{ [size]: [filepath] }
```
Now source can be array of paths. And better to use `sizeOf` function instead of:
```
sourceset.push({
    size: { width: size, height: size, type: 'png' },
    file: buffer
});
```
### 2. Firefox icon
Overlay should be behind main icon.
Icon from RFG:
![rfg](https://puu.sh/qJlIr/d45b33ac8c.png)
Before (without offset):
![before](https://puu.sh/qJlMQ/b77e950ace.png)
After (with offset):
![after](https://puu.sh/qJlOW/8ca5a3f598.png) 
### 3. HTML tags from RFG
Before:
```js
html: [ '<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">\n<link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">\n<link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">\n<link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">\n<link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">\n<link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">\n<link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">\n<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">\n<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">\n<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">\n<link rel="icon" type="image/png" href="/favicon-230x230.png" sizes="230x230">\n<link rel="icon" type="image/png" href="/android-chrome-192x192.png" sizes="192x192">\n<link rel="icon" type="image/png" href="/coast-228x228.png" sizes="228x228">\n<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">\n<link rel="manifest" href="/manifest.json">\n<link rel="yandex-tableau-widget" href="/yandex-browser-manifest.json">\n<meta name="theme-color" content="#0030d9">' ] }
```
After:
```js
html: 
   [ '<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">',
     '<link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">',
     '<link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">',
     '<link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">',
     '<link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">',
     '<link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">',
     '<link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">',
     '<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">',
     '<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">',
     '<meta name="apple-mobile-web-app-capable" content="yes">',
     '<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">',
     '<meta name="apple-mobile-web-app-title">',
     '<link rel="icon" type="image/png" sizes="228x228" href="/coast-228x228.png">',
     '<link rel="yandex-tableau-widget" href="/yandex-browser-manifest.json">',
     '<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">',
     '<link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">',
     '<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">',
     '<link rel="shortcut icon" href="/favicon.ico">',
     '<link rel="manifest" href="/manifest.json">',
     '<meta name="mobile-web-app-capable" content="yes">',
     '<meta name="theme-color" content="#0030d9">',
     '<meta name="application-name">' ] }
```
### 4. Offset fix
- I also fixed some troubles with offset in firefox icon.
- Now offset size should be calculated right.

### 5. Convert color to HEX for RFG
RFG throws error if color is not in HEX format. Now color converts to HEX.

# Mods
### 1. Partial offline SVG support
Now if sourceset contains SVG source, new image will be generated instead of resizing PNG source.
Before (from 512x512 PNG):
![before](https://puu.sh/qJm5R/fa4c02fd72.png)
After (from SVG):
![after](https://puu.sh/qJmbH/ba0e05fb9f.png)
### 2. Offsets with RFG
Now offset parameters will be applied to the RFG request.
### 3. Platform options
Certain parameters can be applied for certain platforms. This rules are described in `config/platform-options.json`. For now it has only one parameter, but in near future I can add some parameters from RFG, which will be available only with `online: true`.
### 4. Prefer online option
If `preferOnline` option is setted to `true` and `online` generation was failed, then icons will be generated offline.