### PR TITLE
Added: `iPad Pro` icon.

### DIFF
--- a/config/icons.json
+++ b/config/icons.json
@@ -121,6 +121,13 @@
       "rotate": false,
       "mask": false
     },
+    "apple-touch-icon-167x167.png": {
+      "width": 167,
+      "height": 167,
+      "transparent": false,
+      "rotate": false,
+      "mask": false
+    },
     "apple-touch-icon-180x180.png": {
       "width": 180,
       "height": 180,


### PR DESCRIPTION
Ref: https://developer.apple.com/ios/human-interface-guidelines/graphics/app-icon/#//apple_ref/doc/uid/TP40006556-CH27-SW2.