### PR TITLE
Fix node version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mkdirp": "^0.5.1",
     "node-rest-client": "^1.5.1",
     "require-directory": "^2.1.1",
-    "svg2png": "^3.0.1",
+    "svg2png": "~3.0.1",
     "through2": "^2.0.0",
     "tinycolor2": "^1.1.2",
     "to-ico": "^1.0.1",


### PR DESCRIPTION
Recent builds of favicons breaks because of an implied need for Node 6+.

Removing the requirement for Node 6+ by:
Locking down svg2png dependency to patch releases only of 3.0.x. This is done since svg2png 3.1.x+ requires node 6+ (https://github.com/domenic/svg2png/releases).