### PR TITLE
Fix malformed favicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "svg2png": "~3.0.1",
     "through2": "^2.0.0",
     "tinycolor2": "^1.1.2",
-    "to-ico": "^1.0.1",
+    "to-ico": "^1.1.2",
     "underscore": "^1.8.3",
     "vinyl": "^1.1.0"
   },


### PR DESCRIPTION
`to-ico` prior 1.1.2 can generates `.ico` file that are not usable by Chrome and FF, cf #155.

I bumped `to-ico` version to 1.1.2 to get the changes made upstream. You can get more context here: https://github.com/kevva/to-ico/issues/8