### PR TITLE
Added "version" to manifest.json

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -192,6 +192,7 @@ const path = require('path'),
                         properties.name = options.appName;
                         properties.short_name = options.appName;
                         properties.description = options.appDescription;
+                        properties.version = options.version || 1;
                         properties.dir = options.dir;
                         properties.lang = options.lang;
                         properties.display = options.display;


### PR DESCRIPTION
According to the [spec](https://developer.chrome.com/extensions/manifest), “version” is
required in manifest.json. If not provided, set version to 1.