### PR TITLE
Fix json/xml file handling from the favicon service

### DIFF
--- a/helpers-es5.js
+++ b/helpers-es5.js
@@ -12,6 +12,7 @@ var path = require('path'),
     colors = require('colors'),
     jsonxml = require('jsontoxml'),
     sizeOf = require('image-size'),
+    xml2js = require('xml2js'),
     async = require('async'),
     mkdirp = require('mkdirp'),
     Jimp = require('jimp'),
@@ -153,9 +154,19 @@ var path = require('path'),
                     }
                 },
                 vinyl: function vinyl(object) {
+                    var contents;
+                    if (object.name.endsWith('.xml')) {
+                        var builder = new xml2js.Builder();
+                        var xml = builder.buildObject(object.contents);
+                        contents = xml;
+                    } else if (object.name.endsWith('.json')) {
+                        contents = JSON.stringify(object.contents);
+                    } else {
+                        contents = object.contents;
+                    }
                     return new File({
                         path: object.name,
-                        contents: Buffer.isBuffer(object.contents) ? object.contents : new Buffer(object.contents)
+                        contents: Buffer.isBuffer(contents) ? contents : new Buffer(contents)
                     });
                 }
             },


### PR DESCRIPTION
The online favicons service is returning valid content-type headers (maybe a recent change, though it's sometime in the last few months), which is causing node-rest-client to convert the raw json buffer into an actual JS object. This then breaks `new Buffer()`, which expects something that `must start with number, buffer, array or string`.

This changes fixes that to re-json and re-xml files based on their extensions. (Otherwise it involvex more drastic changes/fixes to node-rest-client and its horrible API)