### PR TITLE
Use relative URLs for all android icons

### DIFF
--- a/config/files.json
+++ b/config/files.json
@@ -43,17 +43,17 @@
     			"type": "image/png"
     		},
         {
-          "src": "\/android-chrome-256x256.png",
+          "src": "android-chrome-256x256.png",
           "sizes": "256x256",
           "type": "image\/png"
         },
         {
-          "src": "\/android-chrome-384x384.png",
+          "src": "android-chrome-384x384.png",
           "sizes": "384x384",
           "type": "image\/png"
         },
         {
-          "src": "\/android-chrome-512x512.png",
+          "src": "android-chrome-512x512.png",
           "sizes": "512x512",
           "type": "image\/png"
         }


### PR DESCRIPTION
Currently the three largest ones are fetched from the root folder, instead of the same folder where the manifest (and the icons) are created.