### PR TITLE
fix: rotate images before centering

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _ = require('underscore'),
     async = require('async'),
@@ -50,28 +50,26 @@ var _ = require('underscore'),
                     }).catch(callback);
                 });
             } else {
-                (function () {
-                    var maximum = Math.max(properties.width, properties.height),
-                        offset = Math.round(maximum / 100 * platformOptions.offset) || 0;
+                var maximum = Math.max(properties.width, properties.height),
+                    offset = Math.round(maximum / 100 * platformOptions.offset) || 0;
 
-                    async.waterfall([function (cb) {
-                        return µ.Images.nearest(sourceset, properties, offset, cb);
-                    }, function (nearest, cb) {
-                        return µ.Images.read(nearest.file, cb);
-                    }, function (buffer, cb) {
-                        return µ.Images.resize(buffer, properties, offset, cb);
-                    }, function (resizedBuffer, cb) {
-                        return µ.Images.create(properties, background, function (error, canvas) {
-                            return cb(error, resizedBuffer, canvas);
-                        });
-                    }, function (resizedBuffer, canvas, cb) {
-                        return µ.Images.composite(canvas, resizedBuffer, properties, offset, maximum, cb);
-                    }, function (composite, cb) {
-                        µ.Images.getBuffer(composite, cb);
-                    }], function (error, buffer) {
-                        return callback(error, { name: name, contents: buffer });
+                async.waterfall([function (cb) {
+                    return µ.Images.nearest(sourceset, properties, offset, cb);
+                }, function (nearest, cb) {
+                    return µ.Images.read(nearest.file, cb);
+                }, function (buffer, cb) {
+                    return µ.Images.resize(buffer, properties, offset, cb);
+                }, function (resizedBuffer, cb) {
+                    return µ.Images.create(properties, background, function (error, canvas) {
+                        return cb(error, resizedBuffer, canvas);
                     });
-                })();
+                }, function (resizedBuffer, canvas, cb) {
+                    return µ.Images.composite(canvas, resizedBuffer, properties, offset, maximum, cb);
+                }, function (composite, cb) {
+                    µ.Images.getBuffer(composite, cb);
+                }], function (error, buffer) {
+                    return callback(error, { name: name, contents: buffer });
+                });
             }
         }
 

--- a/helpers.js
+++ b/helpers.js
@@ -279,6 +279,12 @@ const path = require('path'),
                 resize: (image, properties, offset, callback) => {
                     print('Images:resize', `Resizing image to contain in ${ properties.width }x${ properties.height } with offset ${ offset }`);
                     let offsetSize = offset * 2;
+
+                    if (properties.rotate) {
+                        print('Images:resize', `Rotating image by ${ROTATE_DEGREES}`);
+                        image.rotate(ROTATE_DEGREES);
+                    }
+
                     image.contain(properties.width - offsetSize, properties.height - offsetSize, Jimp.HORIZONTAL_ALIGN_CENTER | Jimp.VERTICAL_ALIGN_MIDDLE);
                     return callback(null, image);
                 },
@@ -289,11 +295,6 @@ const path = require('path'),
                         offsetWidth = properties.width - maximumWithOffset > 0 ? (properties.width - maximumWithOffset) / 2 : 0,
                         circle = path.join(__dirname, 'mask.png'),
                         overlay = path.join(__dirname, 'overlay.png');
-
-                    if (properties.rotate) {
-                        print('Images:composite', `Rotating image by ${ROTATE_DEGREES}`);
-                        image.rotate(ROTATE_DEGREES);
-                    }
 
                     const compositeIcon = () => {
                         print('Images:composite', `Compositing ${ maximum }x${ maximum } favicon on ${ properties.width }x${ properties.height } canvas with offset ${ offset }`);

--- a/test/rfg.html
+++ b/test/rfg.html
@@ -18,14 +18,13 @@
 <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" href="images/apple-touch-startup-image-750x1294.png">
 <link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 1)" href="images/apple-touch-startup-image-768x1004.png">
 <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="images/favicon-194x194.png" sizes="194x194">
 <link rel="icon" type="image/png" href="images/android-chrome-192x192.png" sizes="192x192">
 <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16">
 <link rel="manifest" href="images/manifest.json">
 <link rel="shortcut icon" href="images/favicon.ico">
 <link rel="yandex-tableau-widget" href="images/yandex-browser-manifest.json">
 <meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="msapplication-TileColor" content="#26353F">
+<meta name="msapplication-TileColor" content="#26353f">
 <meta name="msapplication-TileImage" content="images/mstile-144x144.png">
 <meta name="msapplication-config" content="images/browserconfig.xml">
-<meta name="theme-color" content="#26353F">
+<meta name="theme-color" content="#26353f">


### PR DESCRIPTION
fixes #162 

There's quite a bit of noise from running `npm test` but the relevant change is in `helpers.js` moving the rotate to the resize block instead of the composite block. 